### PR TITLE
use apiVersion: apps/v1 in guestbook-all-in-one

### DIFF
--- a/guestbook-all-in-one.yaml
+++ b/guestbook-all-in-one.yaml
@@ -16,12 +16,17 @@ spec:
     tier: backend
     role: master
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis-master
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+      role: master
+      tier: backend
   template:
     metadata:
       labels:
@@ -56,12 +61,17 @@ spec:
     tier: backend
     role: slave
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis-slave
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: redis
+      role: slave
+      tier: backend
   template:
     metadata:
       labels:
@@ -106,12 +116,16 @@ spec:
     app: guestbook
     tier: frontend
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: frontend
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: guestbook
+      tier: frontend
   template:
     metadata:
       labels:


### PR DESCRIPTION
in order to avoid kubectl error `no matches for kind "Deployment" in version "extensions/v1beta1"`

## Description
replace extensions/v1beta1 with apps/v1

<!--- Why is this change required? What problem does it solve? -->
in order to avoid kubectl error `no matches for kind "Deployment" in version "extensions/v1beta1"`

Encountered while working on qwiklabs "Palo Alto Networks VM-Series Firewall: Securing the GKE Perimeter"
https://google.qwiklabs.com/games/1323/labs/5948

## How Has This Been Tested?

With the proposed changes I was able to run `kubectl apply -f` and finish the lab.

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
